### PR TITLE
Update Plugin to be supported in Scipion 3.0

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,9 +1,3 @@
-
-=======================
-support for this plugin has been dropped starting with scipion 3.0
-=======================
-
-
 =======================
 Powerfit scipion plugin
 =======================

--- a/powerfit_scipion/__init__.py
+++ b/powerfit_scipion/__init__.py
@@ -63,7 +63,6 @@ class Plugin(pwem.Plugin):
                        tar='powerfit.tgz',
                        targets=['powerfit-2.0*'],
                        pythonMod=True,
-                       deps=['numpy', 'scipy', 'fftw3'],
                        default=True)
 
 

--- a/powerfit_scipion/__init__.py
+++ b/powerfit_scipion/__init__.py
@@ -28,26 +28,27 @@ This sub-package contains data and protocol classes
 wrapping Powerfit programs https://github.com/haddocking/powerfit
 """
 import os
-import pyworkflow.em
-from pyworkflow.utils import Environ
+import pwem
+import pyworkflow.utils as pwutils
 from powerfit_scipion.constants import POWERFIT_HOME, V2_0
 
 
 _logo = "powerfit_logo.gif"
 
 
-class Plugin(pyworkflow.em.Plugin):
+class Plugin(pwem.Plugin):
     _homeVar = POWERFIT_HOME
 
     @classmethod
-    def getEnviron(cls):
+    def getEnviron(cls, first=True):
         """ Setup the environment variables needed to launch powerfit. """
-        environ = Environ(os.environ)
+        # environ = Environ(os.environ)
+        environ = pwutils.Environ()
         environ.update({
             'PATH': Plugin.getHome(),
             'LD_LIBRARY_PATH': str.join(cls.getHome(), 'powerfitlib')
                                + ":" + cls.getHome(),
-        }, position=Environ.BEGIN)
+        }, position=pwutils.Environ.BEGIN)
 
         return environ
 
@@ -66,4 +67,4 @@ class Plugin(pyworkflow.em.Plugin):
                        default=True)
 
 
-pyworkflow.em.Domain.registerPlugin(__name__)
+pwem.Domain.registerPlugin(__name__)

--- a/powerfit_scipion/__init__.py
+++ b/powerfit_scipion/__init__.py
@@ -33,11 +33,13 @@ import pyworkflow.utils as pwutils
 from powerfit_scipion.constants import POWERFIT_HOME, V2_0
 
 
+__version__ = '3.0.0'
 _logo = "powerfit_logo.gif"
 
 
 class Plugin(pwem.Plugin):
     _homeVar = POWERFIT_HOME
+    _url = "https://github.com/scipion-em/scipion-em-powerfit"
 
     @classmethod
     def getEnviron(cls, first=True):
@@ -64,6 +66,3 @@ class Plugin(pwem.Plugin):
                        targets=['powerfit-2.0*'],
                        pythonMod=True,
                        default=True)
-
-
-pwem.Domain.registerPlugin(__name__)

--- a/powerfit_scipion/protocols/__init__.py
+++ b/powerfit_scipion/protocols/__init__.py
@@ -24,4 +24,4 @@
 # *
 # **************************************************************************
 
-from protocol_powerfit import PowerfitProtRigidFit
+from .protocol_powerfit import PowerfitProtRigidFit

--- a/powerfit_scipion/protocols/protocol_powerfit.py
+++ b/powerfit_scipion/protocols/protocol_powerfit.py
@@ -25,9 +25,12 @@
 # *
 # **************************************************************************
 import os
-from pyworkflow.em import *
-from pyworkflow.em.convert import Ccp4Header
-from pyworkflow.em.viewers.viewer_chimera import Chimera
+from pwem import *
+from pwem.convert import Ccp4Header
+from pwem.objects import AtomStruct
+from pwem.protocols import ProtFitting3D, PointerParam, StringParam, basename
+from pwem.viewers.viewer_chimera import Chimera
+from pyworkflow.protocol import FloatParam, IntParam, BooleanParam, Float
 from pyworkflow.protocol.constants import LEVEL_ADVANCED
 from pyworkflow.utils import *
 
@@ -90,16 +93,16 @@ class PowerfitProtRigidFit(ProtFitting3D):
             AtomicStructHandler = importFromPlugin('chimera.atom_struct',
                                                    'AtomicStructHandler')
         else:
-            from pyworkflow.em.convert.atom_struct import AtomicStructHandler
+            from pwem.convert.atom_struct import AtomicStructHandler
 
         _localInputVol = "volume.mrc"
         localInputVol = self._getExtraPath(_localInputVol)
         if self.inputVol.get() is None:
             volume = self.inputPDB.get().getVolume()
-            print "Volume: Volume associated to atomic structure %s\n" % volume
+            print("Volume: Volume associated to atomic structure %s\n" % volume)
         else:
             volume = self.inputVol.get()
-            print "Volume: Input volume %s\n" % volume
+            print("Volume: Input volume %s\n" % volume)
         sampling = volume.getSamplingRate()
         origin = volume.getOrigin(force=True).getShifts()
 

--- a/powerfit_scipion/tests/__init__.py
+++ b/powerfit_scipion/tests/__init__.py
@@ -24,4 +24,4 @@
 # *
 # **************************************************************************
 
-from test_powerfit import TestImportBase, TestImportData, TestPowerFit
+from .test_powerfit import TestImportBase, TestImportData, TestPowerFit

--- a/powerfit_scipion/tests/test_powerfit.py
+++ b/powerfit_scipion/tests/test_powerfit.py
@@ -26,21 +26,10 @@
 # volume or a unit cell extracted from a map volume. Here we are going to test
 # the protocol of rigid fitting powerfit
 
-import os.path
 from pyworkflow.tests import *
-from pyworkflow.utils import importFromPlugin
-from pyworkflow.em.protocol.protocol_import import (ProtImportPdb,
-                                                    ProtImportVolumes)
-
+from pwem.protocols.protocol_import import (ProtImportPdb,
+                                           ProtImportVolumes)
 from powerfit_scipion.protocols import PowerfitProtRigidFit
-
-# ChimeraProtRigidFit = importFromPlugin('chimera.protocols.protocol_fit',
-#                                        'ChimeraProtRigidFit', doRaise=True)
-#
-# CootRefine = importFromPlugin('ccp4.protocols.protocol_coot', 'CootRefine',
-#                               doRaise=True)
-# CCP4ProtRunRefmac = importFromPlugin('ccp4.protocols.protocol_refmac',
-#                                      'CCP4ProtRunRefmac')
 
 
 class TestImportBase(BaseTest):
@@ -122,7 +111,7 @@ class TestPowerFit(TestImportData):
     """
 
     def testPowerFitFromVolAndPDB(self):
-        print "Run powerfit from imported volume and pdb file"
+        print("Run powerfit from imported volume and pdb file")
         # This test checks that powerfit runs with a volume provided
         # directly as inputVol
 
@@ -141,7 +130,7 @@ class TestPowerFit(TestImportData):
                              "There was a problem with the alignment")
 
     def testPowerFitFromVolAndmmCIF(self):
-        print "Run powerfit from imported volume and mmCIF file"
+        print("Run powerfit from imported volume and mmCIF file")
         # This test checks that powerfit runs with a volume provided
         # directly as inputVol
 
@@ -160,7 +149,7 @@ class TestPowerFit(TestImportData):
                              "There was a problem with the alignment")
 
     def testPowerFitFromVolAssocToPDB(self):
-        print "Run powerfit from imported pdb file and volume associated"
+        print("Run powerfit from imported pdb file and volume associated")
         # This test checks that powerfit runs when a volume is provided
         # associated to the imput PDB and not directly as inputVol
 
@@ -178,7 +167,7 @@ class TestPowerFit(TestImportData):
                              "There was a problem with the alignment")
 
     def testPowerFitFromVolAssocTommCIF(self):
-        print "Run powerfit from imported mmCIF file and volume associated"
+        print("Run powerfit from imported mmCIF file and volume associated")
         # This test checks that powerfit runs when a volume is provided
         # associated to the imputPDB and not directly as inputVol
 
@@ -196,8 +185,8 @@ class TestPowerFit(TestImportData):
                              "There was a problem with the alignment")
 
     def testPowerFitFromPDBWithoutVol(self):
-        print "Run powerfit from imported pdb file without imported or " \
-              "pdb-associated volume"
+        print("Run powerfit from imported pdb file without imported or " \
+              "pdb-associated volume")
         # This test corroborates that powerfit does not run unless a volume
         # is provided (directly as inputVol or associated to the imputPDB)
 
@@ -217,15 +206,15 @@ class TestPowerFit(TestImportData):
             self.launchProtocol(protPower)
         except Exception as e:
             self.assertTrue(True)
-            print "This test should return a error message as '" \
-                  " ERROR running protocol scipion - rigid fit"
+            print("This test should return a error message as '" \
+                  " ERROR running protocol scipion - rigid fit")
 
             return
         self.assertTrue(False)
 
     def testPowerFitFrommmCIFWithoutVol(self):
-        print "Run powerfit from imported mmCIF file without imported or " \
-              "mmCIF-associated volume"
+        print("Run powerfit from imported mmCIF file without imported or " \
+              "mmCIF-associated volume")
         # This test corroborates that powerfit does not run unless a volume
         # is provided (directly as inputVol or associated to the imputPDB)
 
@@ -245,8 +234,8 @@ class TestPowerFit(TestImportData):
             self.launchProtocol(protPower)
         except Exception as e:
             self.assertTrue(True)
-            print "This test should return a error message as '" \
-                  " ERROR running protocol scipion - rigid fit"
+            print("This test should return a error message as '" \
+                  " ERROR running protocol scipion - rigid fit")
 
             return
         self.assertTrue(False)

--- a/powerfit_scipion/viewers/__init__.py
+++ b/powerfit_scipion/viewers/__init__.py
@@ -1,2 +1,2 @@
 
-from viewer_powerfit import PowerfitProtRigidFitViewer
+from .viewer_powerfit import PowerfitProtRigidFitViewer

--- a/powerfit_scipion/viewers/viewer_powerfit.py
+++ b/powerfit_scipion/viewers/viewer_powerfit.py
@@ -26,8 +26,8 @@
 # **************************************************************************
 
 from pyworkflow.viewer import DESKTOP_TKINTER, WEB_DJANGO, ProtocolViewer
-from pyworkflow.em.viewers import ChimeraView, ObjectView
-from pyworkflow.em.viewers.showj import MODE, MODE_MD, ORDER, VISIBLE, SORT_BY
+from pwem.viewers import ChimeraView, ObjectView
+from pwem.viewers.showj import MODE, MODE_MD, ORDER, VISIBLE, SORT_BY
 from powerfit_scipion.protocols import PowerfitProtRigidFit
 import pyworkflow.protocol.params as params
 

--- a/powerfit_scipion/viewers/viewer_powerfit.py
+++ b/powerfit_scipion/viewers/viewer_powerfit.py
@@ -55,7 +55,7 @@ class PowerfitProtRigidFitViewer(ProtocolViewer):
 
     def _visualizeFit(self, e=None):
         import os
-        fnCmd = self.protocol._getExtraPath('chimera_%d.cmd' %
+        fnCmd = self.protocol._getExtraPath('chimera_%d.cxc' %
                                             self.modelNumber)
         if os.path.exists(fnCmd):
             return [ChimeraView(fnCmd)]

--- a/powerfit_scipion/wizards.py
+++ b/powerfit_scipion/wizards.py
@@ -28,7 +28,9 @@ This module implement some wizards
 """
 
 
-from pyworkflow.em.wizard import *
+from pwem.wizard import *
+from pwem.wizards import PDBVolumeWizard
+
 from powerfit_scipion.protocols import PowerfitProtRigidFit
 
 #===============================================================================

--- a/powerfit_scipion/wizards.py
+++ b/powerfit_scipion/wizards.py
@@ -28,8 +28,7 @@ This module implement some wizards
 """
 
 
-from pwem.wizard import *
-from pwem.wizards import PDBVolumeWizard
+from pwem.wizards import *
 
 from powerfit_scipion.protocols import PowerfitProtRigidFit
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-scipion-em-chimera==3.0.0
+scipion-em-chimera
 numpy
 scipy

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,3 @@
-# scipion-em-chimera==3.0.0
+scipion-em-chimera==3.0.0
+numpy
+scipy

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-scipion-em-chimera==2.0.1
+# scipion-em-chimera==3.0.0

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ setup(
     # For a discussion on single-sourcing the version across setup.py and the
     # project code, see
     # https://packaging.python.org/en/latest/single_source_version.html
-    version='2.0.2',  # Required
+    version='3.0.0',  # Required
 
     # This is a one-line description or tagline of what your project does. This
     # corresponds to the "Summary" metadata field:
@@ -68,7 +68,7 @@ setup(
 
     # This should be your name or the name of the organization which owns the
     # project.
-    author='I2PC, Roberto Marabini and Marta Martinez',  # Optional
+    author='Roberto Marabini and Marta Martinez',  # Optional
 
     # This should be a valid email address corresponding to the author listed
     # above.

--- a/setup.py
+++ b/setup.py
@@ -159,9 +159,7 @@ setup(
     #
     # For example, the following would provide a command called `sample` which
     # executes the function `main` from this package when invoked:
-    #entry_points={  # Optional
-    #    'console_scripts': [
-    #        'sample=sample:main',
-    #    ],
-    #},
+    entry_points={  # Optional
+       'pyworkflow.plugin': ['powerfit_scipion = powerfit_scipion'],
+    },
 )

--- a/setup.py
+++ b/setup.py
@@ -11,6 +11,8 @@ from setuptools import setup, find_packages
 from codecs import open
 from os import path
 
+from powerfit_scipion import __version__
+
 here = path.abspath(path.dirname(__file__))
 
 # Get the long description from the README file
@@ -43,7 +45,7 @@ setup(
     # For a discussion on single-sourcing the version across setup.py and the
     # project code, see
     # https://packaging.python.org/en/latest/single_source_version.html
-    version='3.0.0',  # Required
+    version=__version__,  # Required
 
     # This is a one-line description or tagline of what your project does. This
     # corresponds to the "Summary" metadata field:


### PR DESCRIPTION
Powerfit plugin is now supported in Scipion 3.0.

The installation of the plugin has been modified to favour the creation of a Conda environment as Powerfit requires Python 2.7 to work properly.