### PR TITLE
Dh plugin fixes

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,3 +1,9 @@
+
+=======================
+support for this plugin has been dropped starting with scipion 3.0
+=======================
+
+
 =======================
 Powerfit scipion plugin
 =======================

--- a/README.rst
+++ b/README.rst
@@ -1,9 +1,3 @@
-
-=======================
-support for this plugin has been dropped starting with scipion 3.0
-=======================
-
-
 =======================
 Powerfit scipion plugin
 =======================

--- a/powerfit_scipion/__init__.py
+++ b/powerfit_scipion/__init__.py
@@ -36,7 +36,7 @@ from powerfit_scipion.constants import POWERFIT_HOME, V2_0
 _logo = "powerfit_logo.gif"
 
 
-class Plugin(pyworkflow.em.Plugin):
+class Plugin(pwem.Plugin):
     _homeVar = POWERFIT_HOME
 
     @classmethod

--- a/powerfit_scipion/__init__.py
+++ b/powerfit_scipion/__init__.py
@@ -62,7 +62,6 @@ class Plugin(pwem.Plugin):
                        tar='powerfit.tgz',
                        targets=['powerfit-2.0*'],
                        pythonMod=True,
-                       deps=['numpy', 'scipy'],
                        default=True)
 
 

--- a/powerfit_scipion/__init__.py
+++ b/powerfit_scipion/__init__.py
@@ -28,7 +28,7 @@ This sub-package contains data and protocol classes
 wrapping Powerfit programs https://github.com/haddocking/powerfit
 """
 import os
-import pyworkflow.em
+import pwem
 from pyworkflow.utils import Environ
 from powerfit_scipion.constants import POWERFIT_HOME, V2_0
 
@@ -66,4 +66,4 @@ class Plugin(pyworkflow.em.Plugin):
                        default=True)
 
 
-pyworkflow.em.Domain.registerPlugin(__name__)
+pwem.Domain.registerPlugin(__name__)

--- a/powerfit_scipion/__init__.py
+++ b/powerfit_scipion/__init__.py
@@ -62,7 +62,7 @@ class Plugin(pwem.Plugin):
                        tar='powerfit.tgz',
                        targets=['powerfit-2.0*'],
                        pythonMod=True,
-                       deps=['numpy', 'scipy', 'fftw3'],
+                       deps=['numpy', 'scipy'],
                        default=True)
 
 

--- a/powerfit_scipion/viewers/viewer_powerfit.py
+++ b/powerfit_scipion/viewers/viewer_powerfit.py
@@ -55,7 +55,7 @@ class PowerfitProtRigidFitViewer(ProtocolViewer):
 
     def _visualizeFit(self, e=None):
         import os
-        fnCmd = self.protocol._getExtraPath('chimera_%d.cmd' %
+        fnCmd = self.protocol._getExtraPath('chimera_%d.cxc' %
                                             self.modelNumber)
         if os.path.exists(fnCmd):
             return [ChimeraView(fnCmd)]

--- a/powerfit_scipion/wizards.py
+++ b/powerfit_scipion/wizards.py
@@ -28,8 +28,7 @@ This module implement some wizards
 """
 
 
-from pwem.wizard import *
-from pwem.wizards import PDBVolumeWizard
+from pwem.wizards import *
 
 from powerfit_scipion.protocols import PowerfitProtRigidFit
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-scipion-em-chimera==3.0
+scipion-em-chimera==3.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-scipion-em-chimera==3.0.0
+scipion-em-chimera
 numpy
 scipy

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,3 @@
 scipion-em-chimera==3.0.0
+numpy
+scipy

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-scipion-em-chimera==2.0.1
+scipion-em-chimera==3.0

--- a/setup.py
+++ b/setup.py
@@ -159,9 +159,7 @@ setup(
     #
     # For example, the following would provide a command called `sample` which
     # executes the function `main` from this package when invoked:
-    #entry_points={  # Optional
-    #    'console_scripts': [
-    #        'sample=sample:main',
-    #    ],
-    #},
+    entry_points={  # Optional
+       'pyworkflow.plugin': ['powerfit_scipion = powerfit_scipion'],
+    },
 )


### PR DESCRIPTION
Powerfit plugin is now supported in Scipion 3.0.

The installation of the plugin has been modified to favour the creation of a Conda environment as Powerfit requires Python 2.7 to work properly.